### PR TITLE
Edited the Mac args to properly open Edge

### DIFF
--- a/edge/config.js
+++ b/edge/config.js
@@ -16,7 +16,7 @@ app.locale = {
 
 app.runtime = {
   mac: {
-    args: ['-a', 'microsoft-edge']
+    args: ['-a', 'Microsoft Edge']
   },
   linux: {
     name: 'microsoft-edge'


### PR DESCRIPTION
Open In Edge isn't working on Mac with the default settings, but if I go into the preferences and change the executable path to "Microsoft Edge" it works. I edited what looks like the default value for Mac in config.js, changing it from `microsoft-edge` to `Microsoft Edge`.