### PR TITLE
fixes #72: Firefox open-in-chrome does not work with URLs that contain start word

### DIFF
--- a/common/common.js
+++ b/common/common.js
@@ -105,10 +105,10 @@ const open = (urls, closeIDs = []) => {
         exec(prefs.path, [...(app.runtime.windows.args2 || []), ...urls], r => response(r, close));
       }
       else {
-        const args = app.runtime.windows.args
-          .map(a => a.replace('%url;', urls.join(' ')))
-          // Firefox is not detaching the process on Windows
-          .map(s => s.replace('start', isFirefox ? 'start /WAIT' : 'start'));
+        const args = [...app.runtime.windows.args];
+        // Firefox is not detaching the process on Windows
+        args[1] = args[1].replace('start', isFirefox ? 'start /WAIT' : 'start');
+        args[2] = args[2].replace('%url;', urls.join(' '));
         exec(app.runtime.windows.name, args, res => {
           // use old method
           if (res && res.code !== 0) {


### PR DESCRIPTION
Borrowed solution from https://github.com/andy-portmen/open-in-chromium/blob/master/worker.js#L135

Closes #72